### PR TITLE
feat(cli): add --version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ npm install -g gitbroski
 ## Usage
 Here are the key commands for gitbroski to enhance your Git workflow:
 
+#### 0. Show Version
+
+Print the installed gitbroski version. Supports aliases `version`, `--version`, and `-v`.
+```bash
+gitbroski --version
+# or
+gitbroski version
+# or
+gitbroski -v
+```
+
 #### 1. Open the Remote Repository
 
 Quickly jump from your command line to the GitHub or GitLab page for your current project.
@@ -56,7 +67,11 @@ go mod tidy
 
 ### 3. Build the Project
 ```bash
+# Basic build (version defaults to "dev")
 go build -o gitbroski ./cmd
+
+# Optional: embed version at build time
+go build -ldflags "-X gitbroski/internal/version.Version=$(jq -r .version package.json 2>/dev/null || echo 0.0.0)" -o gitbroski ./cmd
 ```
 
 ### 4. (Optional) Create a Symlink for Global Use

--- a/internal/commands/version.go
+++ b/internal/commands/version.go
@@ -1,0 +1,17 @@
+package commands
+
+import (
+	"gitbroski/internal/version"
+	"gitbroski/utils/logger"
+)
+
+func init() {
+	Register("version", Version)
+	Register("--version", Version)
+	Register("-v", Version)
+}
+
+// Version prints the current gitbroski version.
+func Version(_ ...string) {
+	logger.Text("gitbroski " + version.Version)
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,8 @@
+// Package version holds the gitbroski CLI version.
+package version
+
+// Version is the current version of the CLI.
+// It can be overridden at build time using:
+//
+//	go build -ldflags "-X gitbroski/internal/version.Version=1.3.0" -o gitbroski ./cmd
+var Version = "dev"


### PR DESCRIPTION
- Add version package exporting Version (defaults to "dev")
- Expose version via CLI aliases: version, --version, -v
- Output format: "gitbroski <version>"
- Update README with usage and build instructions
- Document build-time version injection via -ldflags

### ldflags usage

Override version at build time:
`go build -ldflags "-X gitbroski/internal/version.Version=1.3.0" -o ./bin/gitbroski ./cmd`
Example using [package.json](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) version (requires jq):
`go build -ldflags "-X gitbroski/internal/version.Version=$(jq -r .version package.json)" -o ./bin/gitbroski ./cmd`