### PR TITLE
feat(cli): add --version flag to print current version (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ npm install -g gitbroski
 ## Usage
 Here are the key commands for gitbroski to enhance your Git workflow:
 
+#### Show version
+Print the currently installed gitbroski version.
+```bash
+gitbroski --version
+# or
+gitbroski -v
+```
+
 #### 1. Open the Remote Repository
 
 Quickly jump from your command line to the GitHub or GitLab page for your current project.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,7 +3,6 @@ package main
 
 import (
 	"gitbroski/internal/commands"
-	"gitbroski/internal/version"
 	"gitbroski/utils/logger"
 	"os"
 )
@@ -16,12 +15,6 @@ func main() {
 	}
 
 	cmd := os.Args[1]
-
-	// Global version flags
-	if cmd == "--version" || cmd == "-v" || cmd == "version" {
-		logger.Text("gitbroski " + version.Version)
-		return
-	}
 	handler, exists := commands.Registry[cmd]
 
 	if !exists {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"gitbroski/internal/commands"
+	"gitbroski/internal/version"
 	"gitbroski/utils/logger"
 	"os"
 )
@@ -15,6 +16,12 @@ func main() {
 	}
 
 	cmd := os.Args[1]
+
+	// Global version flags
+	if cmd == "--version" || cmd == "-v" || cmd == "version" {
+		logger.Text("gitbroski " + version.Version)
+		return
+	}
 	handler, exists := commands.Registry[cmd]
 
 	if !exists {

--- a/internal/commands/version.go
+++ b/internal/commands/version.go
@@ -1,0 +1,14 @@
+package commands
+
+import "gitbroski/internal/services"
+
+func init() {
+	// Register canonical command and common flag aliases
+	Register("version", version)
+	Register("--version", version)
+	Register("-v", version)
+}
+
+func version(_ ...string) {
+	services.PrintVersion()
+}

--- a/internal/services/version.go
+++ b/internal/services/version.go
@@ -1,0 +1,11 @@
+package services
+
+import (
+	"gitbroski/internal/version"
+	"gitbroski/utils/logger"
+)
+
+// PrintVersion outputs the CLI name and current version.
+func PrintVersion() {
+	logger.Text("gitbroski " + version.Version)
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+// Version represents the current version of the gitbroski CLI.
+// It is intended to be overridden at build time using:
+//
+//	-ldflags "-X 'gitbroski/internal/version.Version=1.3.0'"
+var Version = "dev"


### PR DESCRIPTION
Adds a global version flag to gitbroski so users can quickly check the installed version. Supports `--version`, `-v`, and `version`. The version string is build-time overridable via Go ldflags to align with release/versioning pipelines.

Closes #19.

## What’s changed

- CLI:
  - Handle global flags: `--version`, `-v`, and `version`
  - Output format: `gitbroski <version>`
- Versioning:
  - Introduce `internal/version.Version` with default `dev`
  - Designed to be overridden during build using ldflags
- Docs:
  - Update `README.md` with usage instructions

## Usage

```bash
gitbroski --version
# or
gitbroski -v
# or
gitbroski version
```

Expected output:
```
gitbroski dev
```
(“dev” by default; see build notes below to inject a real version.)  

## Build and release notes

To set the real version during build, pass ldflags:

```bash
go build -ldflags "-X 'gitbroski/internal/version.Version=1.3.0'" -o bin/gitbroski ./cmd
```

- For release pipelines that build platform-specific binaries (used by `index.js`), apply the same ldflags to each target so `gitbroski --version` reports the correct release version.
- No changes required in the Node wrapper; it forwards args to the compiled binary.