### PR TITLE
docs: add Windows setup instructions to README(issue #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ npm install -g gitbroski
 			```bash
 			ln -s /c/Users/<YourUserName>/gitbroski/gitbroski.exe /usr/bin/gitbroski
 			```
-4. **Verify Installation**
+            > ⚠️ Replace /c/Users/<YourUserName>/gitbroski/ with your actual path.
+5. **Verify Installation**
 		```bash
 		gitbroski --version
 		```

--- a/README.md
+++ b/README.md
@@ -77,9 +77,8 @@ npm install -g gitbroski
 			```
 		- Git Bash (Admin):
 			```bash
-			ln -s /c/Users/Diksha/gitbroski/gitbroski.exe /usr/bin/gitbroski
+			ln -s /c/Users/<YourUserName>/gitbroski/gitbroski.exe /usr/bin/gitbroski
 			```
-		> ⚠️ Replace `/c/Users/Diksha/gitbroski/` with your actual path.
 4. **Verify Installation**
 		```bash
 		gitbroski --version

--- a/README.md
+++ b/README.md
@@ -1,98 +1,167 @@
-# Git-Broski 
+bash
+gitbroski open
+bash
+gitbroski ignore <Language>
+bash
+gitbroski empty commit <your-Message>
+git clone https://github.com/gitbroskie/gitbroski.git
+bash
+go mod tidy
+go build -o gitbroski ./cmd
+git clone https://github.com/gitbroskie/gitbroski.git
+powershell
+go build -o gitbroski.exe ./cmd
+gitbroski --version
+bash
+go mod tidy
+bash
+go build -o gitbroski ./cmd
+bash
+# Git-Broski 🚀
 
-https://gratis-neon-644.notion.site/GitBroski-Broski-for-your-Github-Workflow-286e41747653800a9cc4f7b014c6cf51
+<p align="center">
+	<img src="https://raw.githubusercontent.com/gitbroskie/gitbroski/main/assets/logo.png" alt="GitBroski Logo" width="120"/>
+</p>
 
-**Broski for your Git!**  
-A CLI tool to perform various manual tasks with single commands
+<p align="center">
+	<b>Broski for your Git!</b><br>
+	<i>A CLI tool to perform various manual tasks with single commands</i>
+</p>
 
-## Installation
-This section guides you through setting up gitbroski locally.
+<p align="center">
+	<a href="https://github.com/gitbroskie/gitbroski/releases"><img src="https://img.shields.io/github/v/release/gitbroskie/gitbroski?style=flat-square" alt="Release"></a>
+	<a href="https://github.com/gitbroskie/gitbroski/blob/main/LICENSE.md"><img src="https://img.shields.io/github/license/gitbroskie/gitbroski?style=flat-square" alt="License"></a>
+	<a href="https://github.com/gitbroskie/gitbroski/issues"><img src="https://img.shields.io/github/issues/gitbroskie/gitbroski?style=flat-square" alt="Issues"></a>
+</p>
+
+---
+
+## 🌐 Overview
+
+Git-Broski is a command-line tool that streamlines your Git workflow by automating common tasks with simple commands.
+
+> [Project Notion Page](https://gratis-neon-644.notion.site/GitBroski-Broski-for-your-Github-Workflow-286e41747653800a9cc4f7b014c6cf51)
+
+---
+
+## 📦 Installation
 
 ### Prerequisites
-1. Ensure Node.js is installed and configured on your system.
 
-### Local Setup
-Install the tool globally using npm by running the following command in your terminal:
+- **Node.js** must be installed and configured on your system.
+
+### Install via npm
+
 ```bash
 npm install -g gitbroski
 ```
-## Usage
-Here are the key commands for gitbroski to enhance your Git workflow:
 
-#### 1. Open the Remote Repository
+### Install via Go (Local Build)
+
+1. **Clone the Repository**
+		```bash
+		git clone https://github.com/gitbroskie/gitbroski.git
+		cd gitbroski
+		```
+2. **Install Dependencies**
+		```bash
+		go mod tidy
+		```
+3. **Build the Project**
+		```bash
+		go build -o gitbroski ./cmd
+		```
+4. **(Optional) Symlink for Global Use (Linux/macOS)**
+		```bash
+		sudo ln -s /full/path/to/gitbroski /usr/local/bin/gitbroski
+		```
+
+### Windows Setup
+
+1. **Clone the Repository**
+		```powershell
+		git clone https://github.com/gitbroskie/gitbroski.git
+		cd gitbroski
+		```
+2. **Build or Download the Binary**
+		- If Go is installed:
+			```powershell
+			go build -o gitbroski.exe ./cmd
+			```
+		- If Go is not installed: Download `gitbroski-windows.exe` from the project folder or [Releases](https://github.com/gitbroskie/gitbroski/releases).
+3. **Add to PATH (Symbolic Link)**
+		- Command Prompt (Admin):
+			```cmd
+			mklink "C:\Program Files\Git\usr\bin\gitbroski.exe" "%cd%\gitbroski.exe"
+			```
+		- Git Bash (Admin):
+			```bash
+			ln -s /c/Users/Diksha/gitbroski/gitbroski.exe /usr/bin/gitbroski
+			```
+		> ⚠️ Replace `/c/Users/Diksha/gitbroski/` with your actual path.
+4. **Verify Installation**
+		```bash
+		gitbroski --version
+		```
+		Expected output:
+		```text
+		GitBroski CLI v1.0.0
+		```
+
+---
+
+## 🚀 Usage
+
+### 1. Open the Remote Repository
 
 Quickly jump from your command line to the GitHub or GitLab page for your current project.
+
 ```bash
 gitbroski open
 ```
-#### 2. Auto-Generate .gitignore
+
+### 2. Auto-Generate .gitignore
+
 Effortlessly create a .gitignore file based on a specified language or technology.
+
 ```bash
 gitbroski ignore <Language>
 ```
-Currently, this command supports:
-- python
-- (Issues are open to add support for node.js, golang, and many more languages!)
 
-#### 3. Easy Empty Commit
+Currently supported:
+- python
+
+> Issues are open to add support for Node.js, Golang, and more!
+
+### 3. Easy Empty Commit
+
 Create an empty Git commit (useful for triggering CI/CD pipelines without code changes) and add an optional message.
+
 ```bash
 gitbroski empty commit <your-Message>
 ```
 
+---
 
-## Installation (Local setup)
+## 🤝 Contributing
 
-### 1. Clone the Repository
-```bash
-git clone https://github.com/your-username/gitbroski.git
-cd gitbroski
-```
-
-### 2. Install Dependencies
-```bash
-go mod tidy
-```
-
-### 3. Build the Project
-```bash
-go build -o gitbroski ./cmd
-```
-
-### 4. (Optional) Create a Symlink for Global Use
-```bash
-sudo ln -s /full/path/to/gitbroski /usr/local/bin/gitbroski
-```
-> This allows you to run `gitbroski` from **any directory**.
-
-- Opens the **current Git repository** in your default browser.
-
-## Contribution Guide
-1. **Fork** and **clone** the repository.
+1. Fork and clone the repository.
 2. Install dependencies:
-```bash
-go mod tidy
-```
+		```bash
+		go mod tidy
+		```
 3. Build the project:
-```bash
-go build -o gitbroski ./cmd
-```
-4. Create a symlink for global use (optional):
-```bash
-sudo ln -s /full/path/to/gitbroski /usr/local/bin/gitbroski
-```
-5. Run `gitbroski` from **any folder** and contribute!
+		```bash
+		go build -o gitbroski ./cmd
+		```
+4. (Optional) Create a symlink for global use:
+		```bash
+		sudo ln -s /full/path/to/gitbroski /usr/local/bin/gitbroski
+		```
+5. Run gitbroski from any folder and contribute!
 
-## License
-MIT
+---
 
-
-
-## 🪟 Windows Setup
-
-Follow these steps to set up **GitBroski** on Windows:
-
-### 1️⃣ Clone the repository
-```powershell
-git clone https://github.com/Diksha78-bot/gitbroski.git
-cd gitbroski
+<p align="center">
+	<i>Made with ❤️ by the GitBroski community</i>
+</p>

--- a/README.md
+++ b/README.md
@@ -1,54 +1,35 @@
-bash
-gitbroski open
-bash
-gitbroski ignore <Language>
-bash
-gitbroski empty commit <your-Message>
-git clone https://github.com/gitbroskie/gitbroski.git
-bash
-go mod tidy
-go build -o gitbroski ./cmd
-git clone https://github.com/gitbroskie/gitbroski.git
-powershell
-go build -o gitbroski.exe ./cmd
-gitbroski --version
-bash
-go mod tidy
-bash
-go build -o gitbroski ./cmd
-bash
 # Git-Broski 🚀
 
 <p align="center">
-	<img src="https://raw.githubusercontent.com/gitbroskie/gitbroski/main/assets/logo.png" alt="GitBroski Logo" width="120"/>
+  <img src="https://raw.githubusercontent.com/gitbroskie/gitbroski/main/assets/logo.png" alt="GitBroski Logo" width="120"/>
 </p>
 
 <p align="center">
-	<b>Broski for your Git!</b><br>
-	<i>A CLI tool to perform various manual tasks with single commands</i>
+  <strong>Broski for your Git!</strong><br>
+  <em>A CLI tool to perform various manual tasks with single commands</em>
 </p>
 
 <p align="center">
-	<a href="https://github.com/gitbroskie/gitbroski/releases"><img src="https://img.shields.io/github/v/release/gitbroskie/gitbroski?style=flat-square" alt="Release"></a>
-	<a href="https://github.com/gitbroskie/gitbroski/blob/main/LICENSE.md"><img src="https://img.shields.io/github/license/gitbroskie/gitbroski?style=flat-square" alt="License"></a>
-	<a href="https://github.com/gitbroskie/gitbroski/issues"><img src="https://img.shields.io/github/issues/gitbroskie/gitbroski?style=flat-square" alt="Issues"></a>
+  <a href="https://github.com/gitbroskie/gitbroski/releases"><img src="https://img.shields.io/github/v/release/gitbroskie/gitbroski?style=flat-square" alt="Release"></a>
+  <a href="https://github.com/gitbroskie/gitbroski/blob/main/LICENSE.md"><img src="https://img.shields.io/github/license/gitbroskie/gitbroski?style=flat-square" alt="License"></a>
+  <a href="https://github.com/gitbroskie/gitbroski/issues"><img src="https://img.shields.io/github/issues/gitbroskie/gitbroski?style=flat-square" alt="Issues"></a>
 </p>
 
 ---
 
-## 🌐 Overview
+## Overview
 
 Git-Broski is a command-line tool that streamlines your Git workflow by automating common tasks with simple commands.
 
-> [Project Notion Page](https://gratis-neon-644.notion.site/GitBroski-Broski-for-your-Github-Workflow-286e41747653800a9cc4f7b014c6cf51)
+> Project Notion Page: https://gratis-neon-644.notion.site/GitBroski-Broski-for-your-Github-Workflow-286e41747653800a9cc4f7b014c6cf51
 
 ---
 
-## 📦 Installation
+## Installation
 
 ### Prerequisites
 
-- **Node.js** must be installed and configured on your system.
+- Node.js (for npm distribution) or Go (to build locally)
 
 ### Install via npm
 
@@ -92,7 +73,7 @@ npm install -g gitbroski
 3. **Add to PATH (Symbolic Link)**
 		- Command Prompt (Admin):
 			```cmd
-			mklink "C:\Program Files\Git\usr\bin\gitbroski.exe" "%cd%\gitbroski.exe"
+			setx PATH "%PATH%;C:\path\to\your\bin"
 			```
 		- Git Bash (Admin):
 			```bash

--- a/README.md
+++ b/README.md
@@ -85,3 +85,14 @@ sudo ln -s /full/path/to/gitbroski /usr/local/bin/gitbroski
 
 ## License
 MIT
+
+
+
+## 🪟 Windows Setup
+
+Follow these steps to set up **GitBroski** on Windows:
+
+### 1️⃣ Clone the repository
+```powershell
+git clone https://github.com/Diksha78-bot/gitbroski.git
+cd gitbroski

--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ const { execFile } = require("child_process");
 const path = require("path");
 const os = require("os");
 
-const platform = os.platform(); 
-const arch = os.arch(); 
+const platform = os.platform();
+const arch = os.arch();
 
 let bin;
 


### PR DESCRIPTION
This PR adds detailed instructions for setting up GitBroski on Windows, addressing issue #1.  
It includes cloning the repo and running GitBroski on Windows, with notes about missing binaries and optional PATH setup.

🙏 If any part of this guide is unclear or requires additional changes, please let me know — I am happy to improve it to make it merge-ready.
